### PR TITLE
parse-datetime fixes - vectorize doy

### DIFF
--- a/R/parse-datetime.r
+++ b/R/parse-datetime.r
@@ -47,11 +47,11 @@ datetime_fn <- function(createdat, mode = "since", permissive = FALSE) {
 get.doy <- function(dates) { as.integer(strftime(as.Date(dates), "%j")) }
 
 is.weekend <- function(date) {
-  weekdays(date) == 'Saturday' | weekdays(date) == 'Sunday'
+  weekdays(date) %in% c('Saturday', 'Sunday')
 }
 
 is.holiday <- function(date) {
-  year <- lubridate::year(as.Date(date))
+  year <- lubridate::year(date)
   holidays_fun <- list(ChristmasDay, USNewYearsDay, USMemorialDay, LaborDay, USThanksgivingDay)
   fun <- function(f, ...) { f(...) }
   holidays <- lapply(lapply(holidays_fun, fun, year), as.Date)

--- a/R/parse-datetime.r
+++ b/R/parse-datetime.r
@@ -26,9 +26,8 @@ datetime_fn <- function(createdat, mode = "since", permissive = FALSE) {
   
   # check to see if any records are converted to NA
   if (any(is.na(datetime[!originally_NA]))) {
-    msg = 'Improper date format.'
-    if (!isTRUE(permissive)) { stop(msg) }
-    else { warning(msg) }
+    error_method <- if (isTRUE(permissive)) warning else stop
+    error_method('Improper date format.')
   }
 
   suppressWarnings(switch(mode,

--- a/R/parse-datetime.r
+++ b/R/parse-datetime.r
@@ -44,13 +44,7 @@ datetime_fn <- function(createdat, mode = "since", permissive = FALSE) {
   ))
 }
 
-get.doy <- function(dates) {
-  vapply(dates, function(date) {
-    thisyear <- lubridate::year(date)
-    janprime <- as.Date(paste(c(thisyear,'1','1'), collapse = '-'))
-    as.numeric(as.Date(date)) - as.numeric(janprime) + 1
-  }, numeric(1))
-}
+get.doy <- function(dates) { as.integer(strftime(as.Date(dates), "%j")) }
 
 is.weekend <- function(date) {
   weekdays(date) == 'Saturday' | weekdays(date) == 'Sunday'

--- a/R/parse-datetime.r
+++ b/R/parse-datetime.r
@@ -47,7 +47,7 @@ datetime_fn <- function(createdat, mode = "since", permissive = FALSE) {
 get.doy <- function(dates) {
   vapply(dates, function(date) {
     thisyear <- lubridate::year(date)
-    janprime <- as.Date(paste(c(thisyear,'1','1'), collapse='-'))
+    janprime <- as.Date(paste(c(thisyear,'1','1'), collapse = '-'))
     as.numeric(as.Date(date)) - as.numeric(janprime) + 1
   }, numeric(1))
 }

--- a/R/parse-datetime.r
+++ b/R/parse-datetime.r
@@ -18,10 +18,10 @@ datetime_fn <- function(createdat, mode = "since", permissive = FALSE) {
   originally_NA <- is.na(createdat)
   
   # do the conversion
-  datetime <- suppressWarnings(lubridate:::ymd_hms(createdat))
+  datetime <- suppressWarnings(lubridate::ymd_hms(createdat))
   if (any(is.na(datetime))) {
     if (mode == 'hod') { stop('Cannot extract hour from date-only.') }
-    datetime <- suppressWarnings(lubridate:::ymd(createdat))
+    datetime <- suppressWarnings(lubridate::ymd(createdat))
   }
   
   # check to see if any records are converted to NA
@@ -32,11 +32,11 @@ datetime_fn <- function(createdat, mode = "since", permissive = FALSE) {
 
   suppressWarnings(switch(mode,
     "since" = as.numeric(as.Date(datetime)),
-    "hod" = lubridate:::hour(datetime),
+    "hod" = lubridate::hour(datetime),
     "dow" = weekdays(datetime),
-    "dom" = lubridate:::day(datetime),
+    "dom" = lubridate::day(datetime),
     "doy" = syberiaMungebits:::get.doy(datetime),
-    "moy" = lubridate:::month(datetime),
+    "moy" = lubridate::month(datetime),
     "holiday" = syberiaMungebits:::is.holiday(datetime),
     "weekend" = syberiaMungebits:::is.weekend(datetime),
     "bizday" = !syberiaMungebits:::is.holiday(datetime) & !syberiaMungebits:::is.weekend(datetime),
@@ -46,7 +46,7 @@ datetime_fn <- function(createdat, mode = "since", permissive = FALSE) {
 
 get.doy <- function(dates) {
   vapply(dates, function(date) {
-    thisyear <- lubridate:::year(date)
+    thisyear <- lubridate::year(date)
     janprime <- as.Date(paste(c(thisyear,'1','1'), collapse='-'))
     as.numeric(as.Date(date)) - as.numeric(janprime) + 1
   }, numeric(1))
@@ -57,7 +57,7 @@ is.weekend <- function(date) {
 }
 
 is.holiday <- function(date) {
-  year <- lubridate:::year(as.Date(date))
+  year <- lubridate::year(as.Date(date))
   holidays_fun <- list(ChristmasDay, USNewYearsDay, USMemorialDay, LaborDay, USThanksgivingDay)
   fun <- function(f, ...) { f(...) }
   holidays <- lapply(lapply(holidays_fun, fun, year), as.Date)

--- a/R/parse-datetime.r
+++ b/R/parse-datetime.r
@@ -11,7 +11,8 @@
 
 #' @param date contains the date to be formatted
 #' @param mode gives the desired output format (see above)
-datetime_fn <- function(createdat, mode="since", permissive=FALSE) {
+#' @param permissive logical. If false, will error with an improper type.  If true, will just warn.
+datetime_fn <- function(createdat, mode = "since", permissive = FALSE) {
   
   # track which records are NA before the mungebit
   originally_NA <- is.na(createdat)
@@ -24,8 +25,10 @@ datetime_fn <- function(createdat, mode="since", permissive=FALSE) {
   }
   
   # check to see if any records are converted to NA
-  if (any(is.na(datetime[!originally_NA])) && !isTRUE(permissive)) { 
-    stop('Improper date format.') 
+  if (any(is.na(datetime[!originally_NA]))) {
+    msg = 'Improper date format.'
+    if (!isTRUE(permissive)) { stop(msg) }
+    else { warning(msg) }
   }
 
   suppressWarnings(switch(mode,

--- a/R/parse-datetime.r
+++ b/R/parse-datetime.r
@@ -49,7 +49,7 @@ get.doy <- function(dates) {
     thisyear <- lubridate:::year(date)
     janprime <- as.Date(paste(c(thisyear,'1','1'), collapse='-'))
     as.numeric(as.Date(date)) - as.numeric(janprime) + 1
-  }, as.numeric(1))
+  }, numeric(1))
 }
 
 is.weekend <- function(date) {

--- a/R/parse-datetime.r
+++ b/R/parse-datetime.r
@@ -42,10 +42,12 @@ datetime_fn <- function(createdat, mode="since", permissive=FALSE) {
   ))
 }
 
-get.doy <- function(date) {
-  thisyear <- lubridate:::year(date)
-  janprime <- as.Date(paste(c(thisyear,'1','1'), collapse='-'))
-  as.numeric(as.Date(date)) - as.numeric(janprime) + 1
+get.doy <- function(dates) {
+  vapply(dates, function(date) {
+    thisyear <- lubridate:::year(date)
+    janprime <- as.Date(paste(c(thisyear,'1','1'), collapse='-'))
+    as.numeric(as.Date(date)) - as.numeric(janprime) + 1
+  }, as.numeric(1))
 }
 
 is.weekend <- function(date) {

--- a/inst/tests/test-parse-datetime.r
+++ b/inst/tests/test-parse-datetime.r
@@ -1,24 +1,24 @@
 context("parse_datetime")
 library(timeDate)
 
-check_date <- function(date, expectation, mode='since') {
+check_date <- function(date, expectation, mode = 'since') {
   mb <- set_mungebit()
   mp <- set_mungeplane(date)
-  mb$run(mp, 1, mode=mode)
+  mb$run(mp, 1, mode = mode)
   eval(substitute(expect_equal(expectation, mp$data$x)))
 }
 
-check_NA <- function(date, mode='since') {
+check_NA <- function(date, mode = 'since') {
   mb <- set_mungebit()
   mp <- set_mungeplane(date)
-  mb$run(mp, 1, mode=mode)
+  mb$run(mp, 1, mode = mode)
   expect_true(is.na(mp$data$x))
 }
   
-check_invalid_date <- function(date, expectation, mode='since') {
+check_invalid_date <- function(date, expectation, mode = 'since') {
   mb <- set_mungebit()
   mp <- set_mungeplane(date)
-  expect_error(mb$run(mp, 1, mode=mode), expectation)
+  expect_error(mb$run(mp, 1, mode = mode), expectation)
 }
 
 set_mungebit <- function() {
@@ -30,10 +30,10 @@ set_mungeplane <- function(date) {
   mungebits:::mungeplane(df)
 }
 
-datetime = '1991-12-11 03:14:15.9265'
-date = '1991-12-11'
-multiple_datetimes = c('1991-01-01 12:34:56.789', '1992-01-01 12:34:56.789', '1993-01-01 12:34:56.789')
-multiple_dates = c('1991-01-01', '1992-01-01', '1993-01-01')
+datetime <- '1991-12-11 03:14:15.9265'
+date <- '1991-12-11'
+multiple_datetimes <- c('1991-01-01 12:34:56.789', '1992-01-01 12:34:56.789', '1993-01-01 12:34:56.789')
+multiple_dates <- c('1991-01-01', '1992-01-01', '1993-01-01')
 test_that("it converts to numeric date", { check_date(datetime, 8014) })
 test_that("it doesn't mind NAs", check_NA(NA))
 test_that("it converts to hour of day", { check_date(datetime, 3, 'hod') })
@@ -54,5 +54,6 @@ test_that("it works on multiple dates", { check_date(multiple_dates, c(7670, 803
 test_that("weekend works on multiple dates", { check_date(multiple_dates, c(FALSE, FALSE, FALSE), 'weekend') })
 test_that("holiday works on multiple dates", { check_date(multiple_dates, c(TRUE, TRUE, TRUE), 'holiday') })
 test_that("bizday works on multiple dates", { check_date(multiple_dates, c(FALSE, FALSE, FALSE), 'bizday') })
+test_that("doy works on multiple dates", { check_date(multiple_dates, c(1, 1, 1), 'doy') })
 test_that("it returns an error if time format is invalid", { check_invalid_date('pizza', 'Improper date') })
 test_that("it returns an error if trying to extract hour from date-only", { check_invalid_date('1991-12-11', 'Cannot extract hour', 'hod') })

--- a/man/datetime_fn.Rd
+++ b/man/datetime_fn.Rd
@@ -18,6 +18,8 @@ datetime_fn(createdat, mode = "since", permissive = FALSE)
 \arguments{
 \item{mode}{gives the desired output format (see above)}
 
+\item{permissive}{logical. If false, will error with an improper type.  If true, will just warn.}
+
 \item{date}{contains the date to be formatted}
 }
 \description{

--- a/man/datetime_fn.Rd
+++ b/man/datetime_fn.Rd
@@ -13,7 +13,7 @@
    if the output is a weekend (\code{TRUE} or \code{FALSE}, use mode="weekend")
    if the output is a business day (\code{TRUE} or \code{FALSE}, use mode="bizday")}
 \usage{
-datetime_fn(createdat, mode = "since")
+datetime_fn(createdat, mode = "since", permissive = FALSE)
 }
 \arguments{
 \item{mode}{gives the desired output format (see above)}


### PR DESCRIPTION
Vectorizes `doy` from `parse-datetime` mungebit, to allow it to be used.

Fixes `permissive` and adds Roxygen documentation, because @rylandely didn't add it. :/