### PR TITLE
Numeric to factor fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Common mungebits used with Syberia projects.
 Type: Package
 Description: A collection of specific transformations to be used in conjuction
     with the mungebits package, designed for syberia models.
-Version: 0.2.3.3.1
+Version: 0.2.3.3.2
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",
@@ -12,7 +12,7 @@ Depends:
     R (>= 3.0.1),
     Rcpp (>= 0.10.6)
 Imports:
-    mungebits(>= 0.3.12.2),
+    mungebits,
     arules,
     statsUtils,
     Ramd,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Depends:
     R (>= 3.0.1),
     Rcpp (>= 0.10.6)
 Imports:
-    mungebits(>= 0.3.12.1),
+    mungebits(>= 0.3.12.2),
     arules,
     statsUtils,
     Ramd,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Common mungebits used with Syberia projects.
 Type: Package
 Description: A collection of specific transformations to be used in conjuction
     with the mungebits package, designed for syberia models.
-Version: 0.2.3b
+Version: 0.2.3.1
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Common mungebits used with Syberia projects.
 Type: Package
 Description: A collection of specific transformations to be used in conjuction
     with the mungebits package, designed for syberia models.
-Version: 0.2.3.1
+Version: 0.2.3.3
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Depends:
     R (>= 3.0.1),
     Rcpp (>= 0.10.6)
 Imports:
-    mungebits,
+    mungebits(>= 0.3.12.1),
     arules,
     statsUtils,
     Ramd,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Common mungebits used with Syberia projects.
 Type: Package
 Description: A collection of specific transformations to be used in conjuction
     with the mungebits package, designed for syberia models.
-Version: 0.2.3.3.2
+Version: 0.2.4
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Common mungebits used with Syberia projects.
 Type: Package
 Description: A collection of specific transformations to be used in conjuction
     with the mungebits package, designed for syberia models.
-Version: 0.2.3
+Version: 0.2.3b
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Common mungebits used with Syberia projects.
 Type: Package
 Description: A collection of specific transformations to be used in conjuction
     with the mungebits package, designed for syberia models.
-Version: 0.2.3.3
+Version: 0.2.3.3.1
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/R/discretizer.r
+++ b/R/discretizer.r
@@ -56,7 +56,7 @@ discretizer_fn <- function(column,
         discretized_column <- try(suppressWarnings(arules::discretize(column,
           digits = syberiaMungebits:::MAX_DISCRETIZATION_DIGITS, method = 'frequency',
           categories = i, ...)))
-        if (inherits(discretized_column, 'try-error')) next 
+        if (inherits(discretized_column, 'try-error')) next
         trimmed_levels <- gsub('^ *| *$', '', levels(discretized_column))
         if (mode_value %in% suppressWarnings(as.numeric(trimmed_levels))) {
           mode_corrected <- TRUE
@@ -69,7 +69,7 @@ discretizer_fn <- function(column,
         warning(paste0("Mode of variable '", colname ,"' is above ", 100 * mode_freq_threshold, "% ",
                 "and/or mode ratio is above ", mode_ratio_threshold, " and no number of buckets between ",
                 min(category_range), " and ", max(category_range), " fixes the problem. May want to ",
-                "discretize manually")) 
+                "discretize manually"))
       }
     }
     if (!mode_corrected) {
@@ -107,7 +107,7 @@ restore_levels_fn <- function(column, missing_level = 'Missing', ...) {
   else {
     previous_missing_values <- is.na(column[[1]])
     col <- syberiaMungebits:::numeric_to_factor(column[[1]], inputs$levels,
-                                                na.to.missing = FALSE) 
+                                                na.to.missing = FALSE)
     if (!is.null(missing_level))
       factor(ifelse(previous_missing_values,
             as.character(missing_level), as.character(col)), levels = levels(col))
@@ -157,5 +157,4 @@ freqs <- function(variable,
   tabulate(match(variable, uniques))
 }
 
-MAX_DISCRETIZATION_DIGITS <- 10
-
+MAX_DISCRETIZATION_DIGITS <- 8

--- a/inst/tests/test-discretizer.r
+++ b/inst/tests/test-discretizer.r
@@ -130,7 +130,7 @@ test_that("it correctly assigns to infinity bins", {
  expected_discretized_column <-
    factor(c(rep(0, 34), rep(1, 33), rep(2, 33)),labels = c('[-Inf, 25)','[  25, 58)','[  58,Inf]'))
 
- df <- mungebits:::mungeplane(data.frame(first = c(seq(-10000,-9991),1:80,seq(9991,10000))))
+ df <- mungebits:::mungeplane(data.frame(first = c(-Inf,seq(-9999,-9991),1:80,seq(9991,9999),Inf)))
  mb$run(df, 1)
  expect_equal(df$data[[1]],
    expected_discretized_column)

--- a/inst/tests/test-discretizer.r
+++ b/inst/tests/test-discretizer.r
@@ -1,3 +1,4 @@
+data(iris_discretized, package = "syberiaMungebits")
 context("discretizer")
 require(mungebits)
 # TODO: (RK) Figure out why this is broken on CI

--- a/inst/tests/test-discretizer.r
+++ b/inst/tests/test-discretizer.r
@@ -38,7 +38,7 @@ test_that("it correctly restores iris data set", {
  if (!mungebits_loaded) unloadNamespace('mungebits')
 })
 #
-test_that("it does not discretize values with uniques below the lower bnd", {
+test_that("it does not discretize values with uniques below the lower bound", {
  mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
  iris2 <- mungebits:::mungeplane(iris)
  mb <- mungebits:::mungebit(discretizer)

--- a/inst/tests/test-discretizer.r
+++ b/inst/tests/test-discretizer.r
@@ -137,17 +137,17 @@ test_that("it correctly assigns to infinity bins", {
    expected_discretized_column)
 })
 
-test_that("it supports up to 6 digits in discretization levels", {
- df <- mungebits:::mungeplane(data.frame(first = 1:100 / 40000))
+test_that("it supports up to 8 digits in discretization levels", {
+ df <- mungebits:::mungeplane(data.frame(first = 1:100 / 4000000))
  mb <- mungebits:::mungebit(discretizer)
  mb$run(df, 1)
  expected_discretized_column <-
-   factor(c(rep("[0.000025,0.000875)", 34), rep("[0.000875,0.001700)", 33),
-            rep("[0.001700,0.002500]", 33)))
+   factor(c(rep("[0.00000025,0.00000875)", 34), rep("[0.00000875,0.00001700)", 33),
+            rep("[0.00001700,0.00002500]", 33)))
  expect_equal(df$data[[1]], expected_discretized_column)
 
  # test prediction
- df <- mungebits:::mungeplane(data.frame(first = (1:100 / 40000)[1:50]))
+ df <- mungebits:::mungeplane(data.frame(first = (1:100 / 4000000)[1:50]))
  mb$run(df, 1)
  expect_equal(df$data[[1]], expected_discretized_column[1:50])
 })

--- a/inst/tests/test-discretizer.r
+++ b/inst/tests/test-discretizer.r
@@ -151,6 +151,7 @@ test_that("it supports up to 6 digits in discretization levels", {
  mb$run(df, 1)
  expect_equal(df$data[[1]], expected_discretized_column[1:50])
 })
+
 #
 #
 test_that("Discretizer Successfully Interacts with Truncators to Truncate Extreme values ", {

--- a/inst/tests/test-discretizer.r
+++ b/inst/tests/test-discretizer.r
@@ -1,220 +1,234 @@
-#context("discretizer")
-#require(mungebits)
+context("discretizer")
+require(mungebits)
 # TODO: (RK) Figure out why this is broken on CI
 #
-#test_that("it correctly discretizes iris data set", {
-#  mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
-#  iris2 <- mungebits:::mungeplane(iris)
-#  mb <- mungebits:::mungebit(discretizer)
-#  mb$run(iris2, 1:4, mode_freq_threshold = 0.2)
-#  expect_equal(iris2$data, iris_discretized,
-#    info = paste0("The iris dataset must have been discretized correctly and ",
-#                  "match the values in the iris_discretized dataset."))
-#  if (!mungebits_loaded) unloadNamespace('mungebits')
-#})
+test_that("it correctly discretizes iris data set", {
+ mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
+ iris2 <- mungebits:::mungeplane(iris)
+ mb <- mungebits:::mungebit(discretizer)
+ mb$run(iris2, 1:4, mode_freq_threshold = 0.2)
+ expect_equal(iris2$data, iris_discretized,
+   info = paste0("The iris dataset must have been discretized correctly and ",
+                 "match the values in the iris_discretized dataset."))
+ if (!mungebits_loaded) unloadNamespace('mungebits')
+})
 #
-#test_that("it correctly restores iris data set", {
-#  mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
-#  iris2 <- mungebits:::mungeplane(iris)
-#  mb <- mungebits:::mungebit(discretizer)
-#  # mode_freq_threshold = 0.15 actually fails to discretize...
-#  mb$run(iris2, 1:4, mode_freq_threshold = 0.2)
-#  # prediction run
-#  one_row_discretized <- iris_discretized[1, , drop = FALSE]
-#  iris2$data <- iris[1, , drop = FALSE]
-#  mb$run(iris2, 1:4)
-#  expect_equal(iris2$data, one_row_discretized,
-#    info = paste0("The discretizer must be able to restore levels using",
-#                  "the levels generated during the training run."))
+test_that("it correctly restores iris data set", {
+ mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
+ iris2 <- mungebits:::mungeplane(iris)
+ mb <- mungebits:::mungebit(discretizer)
+ # mode_freq_threshold = 0.15 actually fails to discretize...
+ mb$run(iris2, 1:4, mode_freq_threshold = 0.2)
+ # prediction run
+ one_row_discretized <- iris_discretized[1, , drop = FALSE]
+ iris2$data <- iris[1, , drop = FALSE]
+ mb$run(iris2, 1:4)
+ expect_equal(iris2$data, one_row_discretized,
+   info = paste0("The discretizer must be able to restore levels using",
+                 "the levels generated during the training run."))
+
+ # for good measure, test multiple row datasets as well
+ ten_rows_discretized <- iris_discretized[1:10, , drop = FALSE]
+ iris2$data <- iris[1:10, , drop = FALSE]
+ mb$run(iris2, 1:4)
+ expect_equal(iris2$data, ten_rows_discretized,
+   info = paste0("The discretizer must be able to restore levels using",
+                 "the levels generated during the training run."))
+ if (!mungebits_loaded) unloadNamespace('mungebits')
+})
 #
-#  # for good measure, test multiple row datasets as well
-#  ten_rows_discretized <- iris_discretized[1:10, , drop = FALSE]
-#  iris2$data <- iris[1:10, , drop = FALSE]
-#  mb$run(iris2, 1:4)
-#  expect_equal(iris2$data, ten_rows_discretized,
-#    info = paste0("The discretizer must be able to restore levels using",
-#                  "the levels generated during the training run."))
-#  if (!mungebits_loaded) unloadNamespace('mungebits')
-#})
+test_that("it does not discretize values with uniques below the lower bnd", {
+ mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
+ iris2 <- mungebits:::mungeplane(iris)
+ mb <- mungebits:::mungebit(discretizer)
+ mb$run(iris2, 1:4, mode_freq_threshold = 0.2,
+        lower_count_bound = 22)
+ # Only the fourth column of iris has <= 22 uniques
+ expect_equal(iris2$data[, -4], iris_discretized[, -4]);
+ expect_equal(iris2$data[, 4], iris[, 4])
+
+ # test prediction
+ iris2 <- mungebits:::mungeplane(iris)
+ mb$run(iris2, 1:4)
+ expect_equal(iris2$data[, -4], iris_discretized[, -4]);
+ expect_equal(iris2$data[, 4], iris[, 4])
+ if (!mungebits_loaded) unloadNamespace('mungebits')
+})
 #
-#test_that("it does not discretize values with uniques below the lower bnd", {
-#  mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
-#  iris2 <- mungebits:::mungeplane(iris)
-#  mb <- mungebits:::mungebit(discretizer)
-#  mb$run(iris2, 1:4, mode_freq_threshold = 0.2,
-#         lower_count_bound = 22)
-#  # Only the fourth column of iris has <= 22 uniques
-#  expect_equal(iris2$data[, -4], iris_discretized[, -4]);
-#  expect_equal(iris2$data[, 4], iris[, 4])
-#
-#  # test prediction
-#  iris2 <- mungebits:::mungeplane(iris)
-#  mb$run(iris2, 1:4)
-#  expect_equal(iris2$data[, -4], iris_discretized[, -4]);
-#  expect_equal(iris2$data[, 4], iris[, 4])
-#  if (!mungebits_loaded) unloadNamespace('mungebits')
-#})
-#
-#test_that("it does not discretize values with uniques above the upper bnd", {
-#  mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
-#  iris2 <- mungebits:::mungeplane(iris)
-#  mb <- mungebits:::mungebit(discretizer)
-#  mb$run(iris2, 1:4, mode_freq_threshold = 0.2,
-#         upper_count_bound = 23)
-#  # Only the fourth column of iris has < 23 uniques
-#  expect_equal(iris2$data[, -4], iris[, -4]);
-#  expect_equal(iris2$data[, 4], iris_discretized[, 4])
-#
-#  # test prediction
-#  iris2 <- mungebits:::mungeplane(iris)
-#  mb$run(iris2, 1:4)
-#  expect_equal(iris2$data[, -4], iris[, -4]);
-#  expect_equal(iris2$data[, 4], iris_discretized[, 4])
-#  if (!mungebits_loaded) unloadNamespace('mungebits')
-#})
+test_that("it does not discretize values with uniques above the upper bnd", {
+ mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
+ iris2 <- mungebits:::mungeplane(iris)
+ mb <- mungebits:::mungebit(discretizer)
+ mb$run(iris2, 1:4, mode_freq_threshold = 0.2,
+        upper_count_bound = 23)
+ # Only the fourth column of iris has < 23 uniques
+ expect_equal(iris2$data[, -4], iris[, -4]);
+ expect_equal(iris2$data[, 4], iris_discretized[, 4])
+
+ # test prediction
+ iris2 <- mungebits:::mungeplane(iris)
+ mb$run(iris2, 1:4)
+ expect_equal(iris2$data[, -4], iris[, -4]);
+ expect_equal(iris2$data[, 4], iris_discretized[, 4])
+ if (!mungebits_loaded) unloadNamespace('mungebits')
+})
 #
 #detach(iris_discretized)
 #
-#test_that("it correctly uses the missing_level argument", {
-#          
-#  df <- mungebits:::mungeplane(data.frame(first = 1:100)); df$data[1, 1] <- NA
-#  mb <- mungebits:::mungebit(discretizer)
-#  mb$run(df, 1, missing_level = "Not here")
+test_that("it correctly uses the missing_level argument", {
+
+ df <- mungebits:::mungeplane(data.frame(first = 1:100)); df$data[1, 1] <- NA
+ mb <- mungebits:::mungebit(discretizer)
+ mb$run(df, 1, missing_level = "Not here")
+
+ expected_discretized_column <-
+   factor(c('Not here', rep('[ 2, 35)', 33), rep('[35, 68)', 33), rep('[68,100]', 33)))
+ expect_equal(df$data[[1]], expected_discretized_column)
+
+ # test prediction
+ df <- mungebits:::mungeplane(data.frame(first = 1:50)); df$data[1, 1] <- NA
+ mb$run(df, 1, missing_level = "Not here")
+ expect_equal(df$data[[1]], expected_discretized_column[1:50])
+})
 #
-#  expected_discretized_column <-
-#    factor(c('Not here', rep('[ 2, 35)', 33), rep('[35, 68)', 33), rep('[68,100]', 33)))
-#  expect_equal(df$data[[1]], expected_discretized_column)
-#
-#  # test prediction
-#  df <- mungebits:::mungeplane(data.frame(first = 1:50)); df$data[1, 1] <- NA
-#  mb$run(df, 1, missing_level = "Not here")
-#  expect_equal(df$data[[1]], expected_discretized_column[1:50])
-#})
-#
-#test_that("it correctly uses the missing_level argument if it is NULL", {
-#  df <- mungebits:::mungeplane(data.frame(first = 1:100)); df$data[1, 1] <- NA
-#  mb <- mungebits:::mungebit(discretizer)
-#  mb$run(df, 1, missing_level = NULL)
-#
-#  expected_discretized_column <-
-#    factor(c(NA, rep('[ 2, 35)', 33), rep('[35, 68)', 33), rep('[68,100]', 33)))
-#  expect_equal(df$data[[1]], expected_discretized_column)
-#
-#  # test prediction
-#  df <- mungebits:::mungeplane(data.frame(first = 1:50)); df$data[1, 1] <- NA
-#  mb$run(df, 1, missing_level = NULL)
-#  expect_equal(df$data[[1]], expected_discretized_column[1:50])
-#})
-#
-#test_that("it leaves values that are not observed in the train set as NA", {
-#  df <- mungebits:::mungeplane(data.frame(first = 1:100))
-#  mb <- mungebits:::mungebit(discretizer)
-#  mb$run(df, 1)
-#  # test prediction
-#  expected_discretized_column <-
-#    factor(c(rep('[ 1, 35)', 34), rep('[35, 68)', 33), rep('[68,100]', 33)))
-#  df <- mungebits:::mungeplane(data.frame(first = 1:150))
-#  mb$run(df, 1)
-#  expect_equal(df$data[[1]],
-#    factor(c(as.character(expected_discretized_column), rep(NA, 50)),
-#           levels = levels(df$data[[1]])))
-#})
-#
-#
-#test_that("it supports up to 10 digits in discretization levels", {
-#  df <- mungebits:::mungeplane(data.frame(first = 1:100 / 4000000))
-#  mb <- mungebits:::mungebit(discretizer)
-#  mb$run(df, 1)
-#  expected_discretized_column <-
-#    factor(c(rep("[0.00000025,0.00000875)", 34), rep("[0.00000875,0.00001700)", 33),
-#             rep("[0.00001700,0.00002500]", 33)))
-#  expect_equal(df$data[[1]], expected_discretized_column)
-#
-#  # test prediction
-#  df <- mungebits:::mungeplane(data.frame(first = (1:100 / 4000000)[1:50]))
-#  mb$run(df, 1)
-#  expect_equal(df$data[[1]], expected_discretized_column[1:50])
-#})
-#
-#
-#test_that("Discretizer Successfully Interacts with Truncators to Truncate Extreme values ", {
-#  mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
-#
-#  xmin = -83.892
-#  xmax = 16.108
-#  
-#  x.train <- seq(xmin,xmax,length.out=100) 
-#  df1 <- data.frame(x=x.train)
-#  mp1 <- mungebits:::mungeplane(df1)
-#  
-#  x.predict <- c(xmin,mean(c(xmin,xmax)),xmax)
-#  df2 <- data.frame(x=x.predict)
-#  mp2 <- mungebits:::mungeplane(df2)
-#    
-#  mbTrunc <- mungebits:::mungebit(truncator)
-#  mbDisc <- mungebits:::mungebit(discretizer)
-#  
-#  mbTrunc$run(mp1)
-#  mbDisc$run(mp1, 1, lower_count_bound=0)
-#  
-#  
-#  mbTrunc$run(mp2)
-#  mbDisc$run(mp2, 1, lower_count_bound=0)
-#  
+test_that("it correctly uses the missing_level argument if it is NULL", {
+ df <- mungebits:::mungeplane(data.frame(first = 1:100)); df$data[1, 1] <- NA
+ mb <- mungebits:::mungebit(discretizer)
+ mb$run(df, 1, missing_level = NULL)
+
+ expected_discretized_column <-
+   factor(c(NA, rep('[ 2, 35)', 33), rep('[35, 68)', 33), rep('[68,100]', 33)))
+ expect_equal(df$data[[1]], expected_discretized_column)
+
+ # test prediction
+ df <- mungebits:::mungeplane(data.frame(first = 1:50)); df$data[1, 1] <- NA
+ mb$run(df, 1, missing_level = NULL)
+ expect_equal(df$data[[1]], expected_discretized_column[1:50])
+})
+
+test_that("it moves values that are not observed in the training set to closest bin", {
+ df <- mungebits:::mungeplane(data.frame(first = 1:100))
+ mb <- mungebits:::mungebit(discretizer)
+ mb$run(df, 1)
+ # test prediction
+ expected_discretized_column <-
+   factor(c(rep('[ 1, 35)', 34), rep('[35, 68)', 33), rep('[68,100]', 33)))
+ df <- mungebits:::mungeplane(data.frame(first = -49:150))
+ mb$run(df, 1)
+ expect_equal(df$data[[1]],
+   factor(c(rep('[ 1, 35)', 50), as.character(expected_discretized_column), rep('[68,100]', 50)),
+          levels = levels(df$data[[1]])))
+})
+
+
+test_that("it correctly assigns to infinity bins", {
+ df <- mungebits:::mungeplane(data.frame(first = c(rep(-Inf,10),1:80,rep(Inf,10))))
+ mb <- mungebits:::mungebit(discretizer)
+ mb$run(df, 1, granularity = 3)
+
+ # test prediction
+ expected_discretized_column <-
+   factor(c(rep(0, 34), rep(1, 33), rep(2, 33)),labels = c('[-Inf, 25)','[  25, 58)','[  58,Inf]'))
+
+ df <- mungebits:::mungeplane(data.frame(first = c(seq(-10000,-9991),1:80,seq(9991,10000))))
+ mb$run(df, 1)
+ expect_equal(df$data[[1]],
+   expected_discretized_column)
+})
+
+test_that("it supports up to 6 digits in discretization levels", {
+ df <- mungebits:::mungeplane(data.frame(first = 1:100 / 40000))
+ mb <- mungebits:::mungebit(discretizer)
+ mb$run(df, 1)
+ expected_discretized_column <-
+   factor(c(rep("[0.000025,0.000875)", 34), rep("[0.000875,0.001700)", 33),
+            rep("[0.001700,0.002500]", 33)))
+ expect_equal(df$data[[1]], expected_discretized_column)
+
+ # test prediction
+ df <- mungebits:::mungeplane(data.frame(first = (1:100 / 40000)[1:50]))
+ mb$run(df, 1)
+ expect_equal(df$data[[1]], expected_discretized_column[1:50])
+})
 #
 #
-#  # check that none of the outputs are missing in discretizer
-#  expect_equal(sum(mp2$data[,1]=="Missing"),0)
-#  if (!mungebits_loaded) unloadNamespace('mungebits')
-#})
+test_that("Discretizer Successfully Interacts with Truncators to Truncate Extreme values ", {
+ mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
+
+ xmin = -83.892
+ xmax = 16.108
+
+ x.train <- seq(xmin,xmax,length.out=100)
+ df1 <- data.frame(x=x.train)
+ mp1 <- mungebits:::mungeplane(df1)
+
+ x.predict <- c(xmin,mean(c(xmin,xmax)),xmax)
+ df2 <- data.frame(x=x.predict)
+ mp2 <- mungebits:::mungeplane(df2)
+
+ mbTrunc <- mungebits:::mungebit(truncator)
+ mbDisc <- mungebits:::mungebit(discretizer)
+
+ mbTrunc$run(mp1)
+ mbDisc$run(mp1, 1, lower_count_bound=0)
+
+
+ mbTrunc$run(mp2)
+ mbDisc$run(mp2, 1, lower_count_bound=0)
+
+
+
+ # check that none of the outputs are missing in discretizer
+ expect_equal(sum(mp2$data[,1]=="Missing"),0)
+ if (!mungebits_loaded) unloadNamespace('mungebits')
+})
 #
-#test_that("Discretizer can handle unforseen Factor Levels", {
-#  mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
-#
-#  xmin = -83.892
-#  xmax = 16.108
-#  
-#  x.train <- seq(xmin,xmax,length.out=100) 
-#  df1 <- data.frame(x=x.train)
-#  mp1 <- mungebits:::mungeplane(df1)
-#  
-#  x.predict <- c(xmin,mean(c(xmin,xmax)),xmax)
-#  df2 <- data.frame(x=x.predict)
-#  mp2 <- mungebits:::mungeplane(df2)
-#    
-#  mbDisc <- mungebits:::mungebit(discretizer)
-#  
-#  mbDisc$run(mp1, 1, lower_count_bound=0)
-#  mbDisc$run(mp2, 1, lower_count_bound=0)
-#  
-#
-#
-#  # check that none of the outputs are missing in discretizer
-#  expect_equal(sum(mp2$data[,1]=="Missing"),0)
-#  if (!mungebits_loaded) unloadNamespace('mungebits')
-#})
-#
-#
-## test_that("it successfully bins values on the boundary of the training phase", {
-#
-##test_that("Within Discretizer It Doesent Contain Factor Gaps", {
-##  
-##  mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
-##  
-##  iris2 <- mungebits:::mungeplane(iris)
-##  iris2$data[100:nrow(iris2$data),1]<-0 
-##   
-##
-##  mb <- mungebits:::mungebit(discretizer)
-##
-##  mb$run(iris2, 1, mode_freq_threshold = .1,granularity = 4)
-##   
-##  # test prediction
-##  iris2 <- mungebits:::mungeplane(iris)
-##  mb$run(iris2, 1:4)
-##  expect_equal(iris2$data[, -4], iris[, -4]);
-##  expect_equal(iris2$data[, 4], iris_discretized[, 4])
-##  
-##  if (!mungebits_loaded) unloadNamespace('mungebits')
-##})
-#  
+test_that("Discretizer can handle unforseen Factor Levels", {
+ mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
+
+ xmin = -83.892
+ xmax = 16.108
+
+ x.train <- seq(xmin,xmax,length.out=100)
+ df1 <- data.frame(x=x.train)
+ mp1 <- mungebits:::mungeplane(df1)
+
+ x.predict <- c(xmin,mean(c(xmin,xmax)),xmax)
+ df2 <- data.frame(x=x.predict)
+ mp2 <- mungebits:::mungeplane(df2)
+
+ mbDisc <- mungebits:::mungebit(discretizer)
+
+ mbDisc$run(mp1, 1, lower_count_bound=0)
+ mbDisc$run(mp2, 1, lower_count_bound=0)
+
+
+
+ # check that none of the outputs are missing in discretizer
+ expect_equal(sum(mp2$data[,1]=="Missing"),0)
+ if (!mungebits_loaded) unloadNamespace('mungebits')
+})
+
+
+# test_that("it successfully bins values on the boundary of the training phase", {
+
+test_that("Within Discretizer It Doesent Contain Factor Gaps", {
+
+ mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
+
+ iris2 <- mungebits:::mungeplane(iris)
+ iris2$data[100:nrow(iris2$data),1]<-0
+
+
+ mb <- mungebits:::mungebit(discretizer)
+
+ mb$run(iris2, 4, mode_freq_threshold = .1,granularity = 3)
+
+ # test prediction
+ iris2 <- mungebits:::mungeplane(iris)
+ mb$run(iris2, 4)
+ expect_equal(iris2$data[, -4], iris[, -4]);
+ expect_equal(iris2$data[, 4], iris_discretized[, 4])
+
+ if (!mungebits_loaded) unloadNamespace('mungebits')
+})

--- a/inst/tests/test-discretizer.r
+++ b/inst/tests/test-discretizer.r
@@ -214,7 +214,7 @@ test_that("Discretizer can handle unforseen Factor Levels", {
 
 # test_that("it successfully bins values on the boundary of the training phase", {
 
-test_that("Within Discretizer It Doesent Contain Factor Gaps", {
+test_that("Within Discretizer It Doesn't Contain Factor Gaps", {
 
  mungebits_loaded <- 'mungebits' %in% loadedNamespaces(); require(mungebits)
 

--- a/src/numeric_to_factor.cpp
+++ b/src/numeric_to_factor.cpp
@@ -3,7 +3,6 @@
 #include <math.h>
 #include <algorithm>
 #include <string>
-#include <iostream>
 using namespace Rcpp;
 
 std::vector<double> _sort_actuals = std::vector<double>();
@@ -84,10 +83,10 @@ CharacterVector numeric_to_factor(NumericVector num,
     if (clean_ranged_levels[j][0] != '[' && clean_ranged_levels[j][0] != '(') {
       // Assume this is just a number
       lefts.push_back(atof(clean_ranged_levels[j]));
-      // lefts[j] = atof(clean_ranged_levels[j]);
+      //lefts[j] = atof(clean_ranged_levels[j]);
       rights.push_back(lefts[j]);
-      // rights[j] = lefts[j];
-      // leftinc[j] = rightinc[j] = true;
+      //rights[j] = lefts[j];
+      //leftinc[j] = rightinc[j] = true;
       leftinc.push_back(true); rightinc.push_back(true);
       continue;
     }
@@ -95,8 +94,8 @@ CharacterVector numeric_to_factor(NumericVector num,
     int levsize = clean_ranged_levels[j].size();
     leftinc.push_back(clean_ranged_levels[j][0] == '[');
     rightinc.push_back(clean_ranged_levels[j][levsize - 1] == ']');
-    // leftinc[j] = clean_ranged_levels[j][0] == '[';
-    // rightinc[j] = clean_ranged_levels[j][levsize - 1] == ']';
+    //leftinc[j] = clean_ranged_levels[j][0] == '[';
+    //rightinc[j] = clean_ranged_levels[j][levsize - 1] == ']';
     // Find the comma
     int comma; for (comma = 0; comma < levsize &&
                    clean_ranged_levels[j][comma] != ','; comma++);

--- a/src/numeric_to_factor.cpp
+++ b/src/numeric_to_factor.cpp
@@ -150,8 +150,8 @@ CharacterVector numeric_to_factor(NumericVector num,
       }
       continue;
     }
-    // Round to 6 digits like R seems to do in discretizer.  Shouldn't be necessary but I think it is.
-    mynum = roundf(mynum * 1000000) / 1000000;
+    // Round to 8 digits like R seems to do in discretizer.  Shouldn't be necessary but I think it is.
+    mynum = roundf(mynum * 100000000) / 100000000;
 
     // Increment until our number is less than the left bin edge
     for (cur = 0; cur < nrlevs; cur++) {

--- a/src/numeric_to_factor.cpp
+++ b/src/numeric_to_factor.cpp
@@ -131,8 +131,18 @@ CharacterVector numeric_to_factor(NumericVector num,
   int h, cur;
   for (int row = 0; row < num.size(); row++) {
     double mynum = num[row];
-    //truncate to match precision of discretizer
-    if (NumericVector::is_na(num[row])) {
+
+    //Explicitly look for Infinity values and assign to far left or far right bins
+    if (mynum == R_NegInf) {
+      charnums[row] = ranged_levels[sorted_indices[0]];
+      continue;
+    } else if (mynum == R_PosInf) {
+        charnums[row] = ranged_levels[sorted_indices[sorted_indices.size() - 1]];
+        continue;
+    }
+
+    //Explicitly look for missing, since out of bounds is no longer missing
+    if (NumericVector::is_na(mynum)) {
       if (na_to_missing) {
         charnums[row] = (String)"Missing";
       } else {

--- a/src/numeric_to_factor.cpp
+++ b/src/numeric_to_factor.cpp
@@ -25,13 +25,11 @@ CharacterVector numeric_to_factor(NumericVector num,
   CharacterVector ranged_levels = CharacterVector();
   CharacterVector other_levels = CharacterVector();
 
-  // keep track of infinity indices
+  // keep track of negative infinity indices.  Positive infinity sorts itself out.
   int neg_inf_index = -1;
-  int pos_inf_index = -1;
   for (int j = 0; j < nlevs; j++) {
     bool other = false;
     bool neg_inf = false;
-    bool pos_inf = false;
     for (unsigned int k = 0; k < strlen(levs[j]); k++ ) {
       if (!(isdigit(levs[j][k]) || levs[j][k] == ',' || levs[j][k] == '.' ||
              levs[j][k] == '(' || levs[j][k] == ')' || levs[j][k] == '[' ||
@@ -42,11 +40,9 @@ CharacterVector numeric_to_factor(NumericVector num,
         break;
       }
       // look for infinity in levels
-      if (levs[j][k] == '-' && k < strlen(levs[j])-3 ) {
+      if (levs[j][k] == '-' && k < strlen(levs[j]) - 3) {
         if(levs[j][k+1] == 'I' && levs[j][k+2] == 'n' && levs[j][k+3] == 'f')
         neg_inf = true;
-      } else if (!neg_inf && levs[j][k] == 'I' && k < strlen(levs[j])-2 ) {
-        if(levs[j][k+1] == 'n' && levs[j][k+2] == 'f') pos_inf = true;
       }
     }
     if (!other) {
@@ -54,7 +50,6 @@ CharacterVector numeric_to_factor(NumericVector num,
       if (neg_inf) {
         neg_inf_index = j;
       }
-      if (pos_inf) pos_inf_index = j;
     }
   }
   if (ranged_levels.size() == 0) {
@@ -163,12 +158,10 @@ CharacterVector numeric_to_factor(NumericVector num,
       }
     }
 
-    // If at leftmost level then either infinity or out of factor bounds to the left so assign to current (cur == 0).
-    // If at infinity index and greater than left bound then also assign to current.
+    // If at leftmost level then either -infinity or out of factor bounds to the left so assign to current (cur == 0).
     // If we're at the last level then we're surely inside that level, since we've accounted for NA_REAL values.
     // If the current left edge is inclusive and we are within epsilon of that edge then we are in that level.
     if (cur == 0 ||
-      (pos_inf_index == h && mynum > lefts[h]) ||
       (cur == nrlevs) ||
       (leftinc[h] && epsilon_compare(mynum, lefts[h]))) {
       charnums[row] = ranged_levels[h];

--- a/src/numeric_to_factor.cpp
+++ b/src/numeric_to_factor.cpp
@@ -26,7 +26,7 @@ CharacterVector numeric_to_factor(NumericVector num,
   CharacterVector ranged_levels = CharacterVector();
   CharacterVector other_levels = CharacterVector();
 
-  //keep track of infinity indices
+  // keep track of infinity indices
   int neg_inf_index = -1;
   int pos_inf_index = -1;
   for (int j = 0; j < nlevs; j++) {
@@ -42,7 +42,7 @@ CharacterVector numeric_to_factor(NumericVector num,
         other_levels.push_back(levs[j]);
         break;
       }
-      //look for infinity in levels
+      // look for infinity in levels
       if (levs[j][k] == '-' && k < strlen(levs[j])-3 ) {
         if(levs[j][k+1] == 'I' && levs[j][k+2] == 'n' && levs[j][k+3] == 'f')
         neg_inf = true;
@@ -84,10 +84,10 @@ CharacterVector numeric_to_factor(NumericVector num,
     if (clean_ranged_levels[j][0] != '[' && clean_ranged_levels[j][0] != '(') {
       // Assume this is just a number
       lefts.push_back(atof(clean_ranged_levels[j]));
-      //lefts[j] = atof(clean_ranged_levels[j]);
+      // lefts[j] = atof(clean_ranged_levels[j]);
       rights.push_back(lefts[j]);
-      //rights[j] = lefts[j];
-      //leftinc[j] = rightinc[j] = true;
+      // rights[j] = lefts[j];
+      // leftinc[j] = rightinc[j] = true;
       leftinc.push_back(true); rightinc.push_back(true);
       continue;
     }
@@ -95,8 +95,8 @@ CharacterVector numeric_to_factor(NumericVector num,
     int levsize = clean_ranged_levels[j].size();
     leftinc.push_back(clean_ranged_levels[j][0] == '[');
     rightinc.push_back(clean_ranged_levels[j][levsize - 1] == ']');
-    //leftinc[j] = clean_ranged_levels[j][0] == '[';
-    //rightinc[j] = clean_ranged_levels[j][levsize - 1] == ']';
+    // leftinc[j] = clean_ranged_levels[j][0] == '[';
+    // rightinc[j] = clean_ranged_levels[j][levsize - 1] == ']';
     // Find the comma
     int comma; for (comma = 0; comma < levsize &&
                    clean_ranged_levels[j][comma] != ','; comma++);
@@ -119,7 +119,7 @@ CharacterVector numeric_to_factor(NumericVector num,
     }
   } // Right & lefts bounds and inclusivity booleans have been set
 
-  //correctly sort negative infinity values trick: Assign -Inf value to minimum left edge value minus 1
+  // correctly sort negative infinity values trick: Assign -Inf value to minimum left edge value minus 1
   if (neg_inf_index != -1){
     lefts.at(neg_inf_index) = min_value - 1;
   }
@@ -146,13 +146,13 @@ CharacterVector numeric_to_factor(NumericVector num,
       }
       continue;
     }
-    //Round to 6 digits like R seems to do in discretizer.  Shouldn't be necessary but I think it is.
+    // Round to 6 digits like R seems to do in discretizer.  Shouldn't be necessary but I think it is.
     mynum = roundf(mynum * 1000000) / 1000000;
 
-    //Increment until our number is less than the left bin edge
+    // Increment until our number is less than the left bin edge
     for (cur = 0; cur < nrlevs; cur++) {
       h = sorted_indices[cur];
-      //To be in the negative infinity bin we have to be less than the next bin over's left-hand side
+      // To be in the negative infinity bin we have to be less than the next bin over's left-hand side
       if (neg_inf_index == h && cur < nrlevs -1) {
         int h2 = sorted_indices[cur+1];
         if (leftinc[h2] ? mynum < lefts[h2] && !epsilon_compare(mynum,lefts[h2]) : mynum < lefts[h2] || epsilon_compare(mynum,lefts[h2])) {
@@ -163,9 +163,11 @@ CharacterVector numeric_to_factor(NumericVector num,
         break;
       }
     }
-    //If at leftmost level then either infinity or out of factor bounds to the left so assign to current (cur == 0).
-    //If at infinity index and greater than left bound then also assign to current.
-    //If we're at the last level then we're surely inside that level, since we've accounted for NA_REAL values.
+
+    // If at leftmost level then either infinity or out of factor bounds to the left so assign to current (cur == 0).
+    // If at infinity index and greater than left bound then also assign to current.
+    // If we're at the last level then we're surely inside that level, since we've accounted for NA_REAL values.
+    // If the current left edge is inclusive and we are within epsilon of that edge then we are in that level.
     if (cur == 0 ||
       (pos_inf_index == h && mynum > lefts[h]) ||
       (cur == nrlevs) ||
@@ -175,10 +177,8 @@ CharacterVector numeric_to_factor(NumericVector num,
     }
     h = sorted_indices[cur - 1]; // back up, we went too far!
 
-    //we are surely not NA, and surely not at the beginning or end.
+    // we are surely not NA, and surely not at the beginning or end.
     charnums[row] = ranged_levels[h];
-
-
   }
 
   return charnums;


### PR DESCRIPTION
This is a pretty drastic change to the numeric_to_factor function.  Previously the function did not handle infinity and set values to NA when they landed outside of the original bins established in discretizer.  We make the change of pushing them into their closest bins now.  We also use machine-epsilon based float comparison and rounding at the 8 digit level (as occurs in discretizer) to ensure that training bin-assignments are replicated in prediction.  All the original discretizer tests pass, but these tests were commented out with the message that they were broken on CI, and I'm not sure what was wrong with them to begin with...