### PR TITLE
Value replacer fix - Optional

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Depends:
     R (>= 3.0.1),
     Rcpp (>= 0.10.6)
 Imports:
-    mungebits(>= 0.3.12.2),
+    mungebits,
     arules,
     statsUtils,
     Ramd,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Depends:
     R (>= 3.0.1),
     Rcpp (>= 0.10.6)
 Imports:
-    mungebits,
+    mungebits(>= 0.3.12.2),
     arules,
     statsUtils,
     Ramd,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Common mungebits used with Syberia projects.
 Type: Package
 Description: A collection of specific transformations to be used in conjuction
     with the mungebits package, designed for syberia models.
-Version: 0.2.4
+Version: 0.2.4.9001
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Common mungebits used with Syberia projects.
 Type: Package
 Description: A collection of specific transformations to be used in conjuction
     with the mungebits package, designed for syberia models.
-Version: 0.2.4.9001
+Version: 0.2.5
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Authors@R: c(person("Robert", "Krzyzanowski",

--- a/R/value_replacer.r
+++ b/R/value_replacer.r
@@ -16,11 +16,14 @@ value_replacer_fn <- function(x, values_map) {
   is_factor <- is.factor(replaced)
   if (is_factor) {
     replaced <- as.character(replaced)
-    rep_levels <- unique(unlist(lapply(values_map, function(value_map) value_map[[2]]))) 
   }
   unnamed_indices <- names(values_map) == ""
-  if (is.null(unnamed_indices) || length(unnamed_indices) == 0)
+  if (is.null(unnamed_indices) || length(unnamed_indices) == 0) {
     unnamed_indices <- TRUE
+  }
+  rep_levels_unnamed <- unlist(lapply(values_map[unnamed_indices], function(value_map) value_map[[2]])) 
+  rep_levels_named <- unlist(lapply(names(values_map)[!unnamed_indices], function(name) values_map[[name]])) 
+  rep_levels <- unique(c(rep_levels_unnamed, rep_levels_named))
   for (value_map in values_map[unnamed_indices]) {
     replaced[x %in% value_map[[1]]] <-
       if (is_factor) as.character(value_map[[2]]) else value_map[[2]]

--- a/R/value_replacer.r
+++ b/R/value_replacer.r
@@ -14,22 +14,31 @@
 value_replacer_fn <- function(x, values_map) { 
   replaced <- x
   is_factor <- is.factor(replaced)
-  if (is_factor) replaced <- as.character(replaced)
+  if (is_factor) {
+    replaced <- as.character(replaced)
+    rep_levels <- unique(unlist(lapply(values_map, function(value_map) value_map[[2]]))) 
+  }
   unnamed_indices <- names(values_map) == ""
   if (is.null(unnamed_indices) || length(unnamed_indices) == 0)
     unnamed_indices <- TRUE
-  for (value_map in values_map[unnamed_indices]) {
-    replaced[x %in% value_map[[1]]] <-
-      if (is_factor) as.character(value_map[[2]]) else value_map[[2]]
-  }
-  for (name in names(values_map)[!unnamed_indices]) {
-    replaced[x == name] <- 
-      if (is_factor) as.character(values_map[[name]]) else values_map[[name]]
-  }
+  lapply(
+    values_map[unnamed_indices]
+    , function(value_map) {
+      replaced[x %in% value_map[[1]]] <<-
+        if (is_factor) as.character(value_map[[2]]) else value_map[[2]]
+    }
+  )
+  lapply(
+    names(values_map)[!unnamed_indices]
+    , function(name) {
+      replaced[x == name] <<- 
+        if (is_factor) as.character(values_map[[name]]) else values_map[[name]]
+    }
+  )
   if (is_factor) factor(replaced, levels =
     if (!exists('inputs')) unique(replaced)
     else if ('levels' %in% names(inputs)) inputs$levels
-    else inputs$levels <<- unique(replaced))
+    else inputs$levels <<- union(unique(replaced), rep_levels))
   else replaced
 }
 

--- a/R/value_replacer.r
+++ b/R/value_replacer.r
@@ -18,10 +18,13 @@ value_replacer_fn <- function(x, values_map) {
   unnamed_indices <- names(values_map) == ""
   if (is.null(unnamed_indices) || length(unnamed_indices) == 0)
     unnamed_indices <- TRUE
- 
-  rep_levels_unnamed <- unlist(lapply(values_map[unnamed_indices], function(value_map) value_map[[2]])) 
-  rep_levels_named <- unlist(lapply(names(values_map)[!unnamed_indices], function(name) values_map[[name]])) 
-  rep_levels <- unique(c(rep_levels_unnamed, rep_levels_named))
+  if (is_factor) { 
+    if (!exists('inputs') || !'levels' %in% names(inputs)) {
+      rep_levels_unnamed <- unlist(lapply(values_map[unnamed_indices], function(value_map) value_map[[2]])) 
+      rep_levels_named <- unlist(lapply(names(values_map)[!unnamed_indices], function(name) values_map[[name]])) 
+      rep_levels <- unique(c(rep_levels_unnamed, rep_levels_named))
+    } else rep_levels <- inputs$levels
+  }
   for (value_map in values_map[unnamed_indices]) {
     replaced[x %in% value_map[[1]]] <-
       if (is_factor) as.character(value_map[[2]]) else value_map[[2]]
@@ -30,10 +33,7 @@ value_replacer_fn <- function(x, values_map) {
     replaced[x == name] <- 
       if (is_factor) as.character(values_map[[name]]) else values_map[[name]]
   }
-  if (is_factor) factor(replaced, levels =
-    if (!exists('inputs')) unique(replaced)
-    else if ('levels' %in% names(inputs)) inputs$levels
-    else inputs$levels <<- union(unique(replaced), rep_levels))
+  if (is_factor) factor(replaced, levels = union(unique(replaced), rep_levels))
   else replaced
 }
 

--- a/R/value_replacer.r
+++ b/R/value_replacer.r
@@ -21,20 +21,14 @@ value_replacer_fn <- function(x, values_map) {
   unnamed_indices <- names(values_map) == ""
   if (is.null(unnamed_indices) || length(unnamed_indices) == 0)
     unnamed_indices <- TRUE
-  lapply(
-    values_map[unnamed_indices]
-    , function(value_map) {
-      replaced[x %in% value_map[[1]]] <<-
-        if (is_factor) as.character(value_map[[2]]) else value_map[[2]]
-    }
-  )
-  lapply(
-    names(values_map)[!unnamed_indices]
-    , function(name) {
-      replaced[x == name] <<- 
-        if (is_factor) as.character(values_map[[name]]) else values_map[[name]]
-    }
-  )
+  for (value_map in values_map[unnamed_indices]) {
+    replaced[x %in% value_map[[1]]] <-
+      if (is_factor) as.character(value_map[[2]]) else value_map[[2]]
+  }
+  for (name in names(values_map)[!unnamed_indices]) {
+    replaced[x == name] <- 
+      if (is_factor) as.character(values_map[[name]]) else values_map[[name]]
+  }
   if (is_factor) factor(replaced, levels =
     if (!exists('inputs')) unique(replaced)
     else if ('levels' %in% names(inputs)) inputs$levels

--- a/R/value_replacer.r
+++ b/R/value_replacer.r
@@ -14,13 +14,11 @@
 value_replacer_fn <- function(x, values_map) { 
   replaced <- x
   is_factor <- is.factor(replaced)
-  if (is_factor) {
-    replaced <- as.character(replaced)
-  }
+  if (is_factor) replaced <- as.character(replaced)
   unnamed_indices <- names(values_map) == ""
-  if (is.null(unnamed_indices) || length(unnamed_indices) == 0) {
+  if (is.null(unnamed_indices) || length(unnamed_indices) == 0)
     unnamed_indices <- TRUE
-  }
+ 
   rep_levels_unnamed <- unlist(lapply(values_map[unnamed_indices], function(value_map) value_map[[2]])) 
   rep_levels_named <- unlist(lapply(names(values_map)[!unnamed_indices], function(name) values_map[[name]])) 
   rep_levels <- unique(c(rep_levels_unnamed, rep_levels_named))

--- a/R/value_replacer.r
+++ b/R/value_replacer.r
@@ -20,8 +20,8 @@ value_replacer_fn <- function(x, values_map) {
     unnamed_indices <- TRUE
   if (is_factor) { 
     if (!exists('inputs') || !'levels' %in% names(inputs)) {
-      rep_levels_unnamed <- unlist(lapply(values_map[unnamed_indices], function(value_map) value_map[[2]])) 
-      rep_levels_named <- unlist(lapply(names(values_map)[!unnamed_indices], function(name) values_map[[name]])) 
+      rep_levels_unnamed <- c(recursive = T, lapply(values_map[unnamed_indices], function(value_map) value_map[[2]])) 
+      rep_levels_named <- c(recursive = T, lapply(names(values_map)[!unnamed_indices], function(name) values_map[[name]])) 
       rep_levels <- unique(c(rep_levels_unnamed, rep_levels_named))
     } else rep_levels <- inputs$levels
   }

--- a/inst/tests/test-value_replacer.r
+++ b/inst/tests/test-value_replacer.r
@@ -100,5 +100,39 @@ test_that("it restores factors correctly", {
                         factor('b', levels = c("b", "a", "d"))))
 })
 
+test_that("it leaves new levels alone", {
+  ###TRAIN
+  train_df <- data.frame(x = factor(c("a", "2", "3", "4", "5", "5")), y = factor(c("a", "b", NA,"c", "d", "d")))
+  mb <- mungebits:::mungebit(value_replacer)
+  mp <- mungebits::mungeplane(train_df)
+  mb$run(mp, is.factor, list(list(NA, "Missing"), list("a", "was_a")))
+
+  ###PREDICT
+  pred_df <- data.frame(x = factor(c("2", "a", "2", "leave_alone")), y = factor(c("a", "b", NA, "leave_alone2")))
+  mp <- mungebits::mungeplane(pred_df)
+  mb$run(mp, is.factor, list(list(NA, "Missing"), list("a", "was_a")))
+  
+  expected_df <- data.frame(x = factor(c("2", "was_a", "2", "leave_alone")), y = factor(c("was_a", "b", "Missing", "leave_alone2")))
+  expect_equal(as.character(mp$data[[1]]),as.character(expected_df[[1]]))
+  expect_equal(as.character(mp$data[[2]]),as.character(expected_df[[2]]))
+})
+
+test_that("it replaces factor NA that it hasn't seen in training", {
+  ###TRAIN
+  train_df <- data.frame(x = factor(c("a", "2", "3", "4", "5", "5")), y = factor(c("a", "b", NA,"c", "d", "d")))
+  mb <- mungebits:::mungebit(value_replacer)
+  mp <- mungebits::mungeplane(train_df)
+  mb$run(mp, is.factor, list(list(NA, "Missing"), list("a", "was_a")))
+
+  ###PREDICT
+  pred_df <- data.frame(x = factor(c("2", "a", NA)), y = factor(c("a", "b", NA)))
+  mp <- mungebits::mungeplane(pred_df)
+  mb$run(mp, is.factor, list(list(NA, "Missing"), list("a", "was_a")))
+  
+  expected_df <- data.frame(x = factor(c("2", "was_a", "Missing")), y = factor(c("was_a", "b", "Missing")))
+  expect_equal(as.character(mp$data[[1]]),as.character(expected_df[[1]]))
+  expect_equal(as.character(mp$data[[2]]),as.character(expected_df[[2]]))
+})
+
 if (!mungebits_loaded) unloadNamespace('mungebits')
 


### PR DESCRIPTION
So, I wanted to ask a quick question about value replacers default behavior and propose the modification found in this branch.  Are we okay with the following code producing NAs in prediction?

```R
###TRAIN
train_df <- data.frame(x = factor(c("1", "2", "3", "4", "5", "5")), y = factor(c("a", "b", NA,"c", "d", "d")))
mb <- mungebits:::mungebit(syberiaMungebits::value_replacer)
mp <- mungebits::mungeplane(train_df)
mb$run(mp, is.factor, list(list(NA, "Missing")))
###PREDICT
pred_df <- data.frame(x = factor(c("2", "3", NA, "6")), y = factor(c("d", "b", NA, "d")))
mp <- mungebits::mungeplane(pred_df)
mb$run(mp, is.factor, list(list(NA, "Missing")))
print(mp$data)
```

Basically, the current behavior of value_replacer only creates the new level when there is a need (corresponding level-to-replace in training data).  In prediction it transforms every level that it hasn't seen before into NA.
This is kind of okay if we run group_minor_levels immediately after and allow for group_new_levels = TRUE, where it will transform those NAs into 'Other,' but often people run this mungebit with the options "exclude = c('NA', 'Missing')"  Below is an example where running group_minor_levels immediately afterwards alleviates the problem:

```R
###TRAIN
train_df <- data.frame(x = factor(c("1", "2", "2", "2", "2")), y = factor(c("a", "b", "b", "b", NA)))
mb <- mungebits:::mungebit(syberiaMungebits::value_replacer)
mp <- mungebits::mungeplane(train_df)
mb$run(mp, is.factor, list(list(NA, "Missing")))
mb2 <- syberia_project()$resource('lib/mungebits/group_minor_levels')$value()
mb2$run(mp, is.factor, min_pct = 0.3, group_new_levels = TRUE, exclude = c("Missing"))
###PREDICT
pred_df <- data.frame(x = factor(c("2", "3", NA, "6")), y = factor(c("d", "b", NA, "d")))
mp <- mungebits::mungeplane(pred_df)
mb$run(mp, is.factor, list(list(NA, "Missing")))
print(mp$data)
mb2$run(mp, is.factor, min_pct = 0.3, group_new_levels = TRUE, exclude = c("Missing"))
print(mp$data)
```

Currently the fix in this branch only addresses NA's from levels defined in value_replacer.  If the replacement level is specified it will leave it in regardless of whether it is present in training.  It does not leave new levels alone, as we might want to do, in order to avoid them being excluded by group_minor_levels calls made with "exclude = c('NA')"
Mind you, this is entirely unnecessary if group_minor_levels is performed immediately without exclude option "exclude = c('NA')"  The only reason I'm worried is because this behavior is not an obvious 'feature' of value_replacer.  It does not follow from it's name that value_replacer is a transformation mungebit turning levels not present during training into NA. 